### PR TITLE
Handling errors in graph.js

### DIFF
--- a/lib/deps/graph.js
+++ b/lib/deps/graph.js
@@ -410,6 +410,9 @@ Graph.prototype.render = function(type_or_options, name_or_callback, errback) {
       }
     } else {
       graphviz = spawn(cmdPath, parameters);
+      graphviz.on('error', function(err) {
+        errback(-1, "", err)
+      });
       graphviz.stdout.on('data', outcallback);
       graphviz.stderr.on('data', function(data) {
         err += data;
@@ -424,8 +427,10 @@ Graph.prototype.render = function(type_or_options, name_or_callback, errback) {
           else if (errback) errback(code, out, err)
         }
       });
-      graphviz.stdin.write(self.to_dot());
-      graphviz.stdin.end();
+      if (graphviz.pid) {
+        graphviz.stdin.write(self.to_dot());
+        graphviz.stdin.end();
+      }
     }
   });
 };


### PR DESCRIPTION
Handle the error when the dot command fails to run (ex. 'dot' is not installed). Write to input only when the command is running.